### PR TITLE
Remove interval while clicking button down

### DIFF
--- a/projects/ngx-tab-scroll/src/lib/tab-scroll.component.ts
+++ b/projects/ngx-tab-scroll/src/lib/tab-scroll.component.ts
@@ -290,6 +290,7 @@ export class TabScrollComponent implements OnInit, OnDestroy, AfterViewInit {
    * @param event native event
    */
   scrollButtonDown(direction, event) {
+    this.cancelMouseDownInterval();
     event.stopPropagation();
     this.isHolding = true;
     const realScroll = direction === 'left' ? 0 - this.scrollByPixels : this.scrollByPixels;


### PR DESCRIPTION
Had an issue where some intervals remain stuck after hitting button. 
To cancel any previous interval while clicking the button should be fine.